### PR TITLE
Geotrellis 3.3.0

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -49,12 +49,12 @@ ingest.
 An example command would look like:
 
 ```
-sbt:geotrellis-spark-job> run --inputPath /tmp/cropped.tif --outputPath file:///tmp/test-catalog
+sbt:geotrellis-spark-job> test:runMain geotrellis.batch.Main --inputPath /tmp/cropped.tif --outputPath file:///tmp/test-catalog
 ```
 
 ## EMR Configuration
 
-This project uses [sbt-lighter plugin](https://github.com/pishen/sbt-lighter) to simplify EMR cluster configuration and Spark jobs deployment. It's important to remember, that some of the Amazon instances are EBS only instances, so check out [instances types description](https://aws.amazon.com/ru/ec2/instance-types/) carefully. By default, [sbt-lighter plugin](https://github.com/pishen/sbt-lighter) allocates only a 32Gb EBS volume, and as a consequence you may experience issues with Spark jobs completion. Consider allocating larger EBS volumes in such cases using the following configurations: 
+This project uses [sbt-lighter plugin](https://github.com/pishen/sbt-lighter) to simplify EMR cluster configuration and Spark jobs deployment. It's important to remember, that some of the Amazon instances are EBS only instances, so check out [instances types description](https://aws.amazon.com/ru/ec2/instance-types/) carefully. By default, [sbt-lighter plugin](https://github.com/pishen/sbt-lighter) allocates only a 32Gb EBS volume, and as a consequence you may experience issues with Spark jobs completion. Consider allocating larger EBS volumes in such cases using the following configurations:
 
 ```scala
 // size in GBs
@@ -63,4 +63,4 @@ sparkMasterEbsSize := Some(64)
 sparkCoreEbsSize := Some(64)
 ```
 
-These should be placed into a `build.sbt` file. The other option would be to use a different instance type that doesn't require EBS volumes usage. 
+These should be placed into a `build.sbt` file. The other option would be to use a different instance type that doesn't require EBS volumes usage.

--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -51,7 +51,7 @@ assemblyMergeStrategy in assembly := {
 // Settings from sbt-lighter plugin that will automate creating and submitting this job to EMR
 import sbtlighter._
 
-sparkEmrRelease := "emr-5.29.0"
+sparkEmrRelease := "$emr_version$"
 sparkAwsRegion := "$aws_region$"
 sparkClusterName := "$name$"
 sparkEmrApplications := Seq("Spark", "Zeppelin", "Ganglia")

--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -5,17 +5,13 @@ version := "0.1.0"
 scalaVersion := "$scala_version$"
 
 libraryDependencies ++= Seq(
-  "com.monovore" %% "decline" % "0.6.2",
+  "com.monovore" %% "decline" % "1.2.0",
   "org.locationtech.geotrellis" %% "geotrellis-spark" % "$geotrellis_version$",
   "org.locationtech.geotrellis" %% "geotrellis-s3" % "$geotrellis_version$",
   "org.locationtech.geotrellis" %% "geotrellis-gdal" % "$geotrellis_version$",
   "org.apache.spark" %% "spark-core" % "$spark_version$" % Provided,
   "org.apache.spark" %% "spark-sql" % "$spark_version$" % Provided,
   "org.apache.spark" %% "spark-hive" % "$spark_version$" % Provided
-)
-
-resolvers ++= Seq(
-  Resolver.url("typesafe", url("http://repo.typesafe.com/typesafe/ivy-releases/"))(Resolver.ivyStylePatterns)
 )
 
 initialCommands in console :=

--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -67,12 +67,6 @@ sparkCoreType := "m4.xlarge"
 sparkInstanceCount := 5
 sparkMasterPrice := Some(0.5)
 sparkCorePrice := Some(0.5)
-sparkEmrBootstrap := List(
-  BootstrapAction("Install GDAL + dependencies",
-                  "s3://geotrellis-test/usbuildings/bootstrap.sh",
-                  "s3://geotrellis-test/usbuildings",
-                  "v1.0")
-)
 sparkEmrServiceRole := "EMR_DefaultRole"
 sparkInstanceRole := "EMR_EC2_DefaultRole"
 sparkMasterEbsSize := Some(64)

--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -8,32 +8,24 @@ libraryDependencies ++= Seq(
   "com.monovore" %% "decline" % "0.6.2",
   "org.locationtech.geotrellis" %% "geotrellis-spark" % "$geotrellis_version$",
   "org.locationtech.geotrellis" %% "geotrellis-s3" % "$geotrellis_version$",
-  "com.azavea.geotrellis" %% "geotrellis-contrib-vlm" % "$geotrellis_contrib_version$",
-  "com.azavea.geotrellis" %% "geotrellis-contrib-gdal" % "$geotrellis_contrib_version$",
+  "org.locationtech.geotrellis" %% "geotrellis-gdal" % "$geotrellis_version$",
   "org.apache.spark" %% "spark-core" % "$spark_version$" % Provided,
   "org.apache.spark" %% "spark-sql" % "$spark_version$" % Provided,
   "org.apache.spark" %% "spark-hive" % "$spark_version$" % Provided
 )
 
 resolvers ++= Seq(
-  "LocationTech Snapshots" at "https://repo.locationtech.org/content/groups/snapshots",
-  "LocationTech Releases" at "https://repo.locationtech.org/content/groups/releases",
-  Resolver.url("typesafe", url("http://repo.typesafe.com/typesafe/ivy-releases/"))(Resolver.ivyStylePatterns),
-  Resolver.bintrayRepo("azavea", "geotrellis")
+  Resolver.url("typesafe", url("http://repo.typesafe.com/typesafe/ivy-releases/"))(Resolver.ivyStylePatterns)
 )
 
 initialCommands in console :=
 """
 import java.net._
-import geotrellis.raster._
+import geotrellis.layer._
 import geotrellis.vector._
-import geotrellis.vector.io._
+import geotrellis.raster._
+import geotrellis.raster.gdal._
 import geotrellis.spark._
-import geotrellis.spark.tiling._
-import geotrellis.contrib.vlm._
-import geotrellis.contrib.vlm.geotiff._
-import geotrellis.contrib.vlm.gdal._
-import geotrellis.contrib.vlm.avro._
 """.stripMargin
 
 // Fork JVM for test context to avoid memory leaks in Metaspace
@@ -63,7 +55,7 @@ assemblyMergeStrategy in assembly := {
 // Settings from sbt-lighter plugin that will automate creating and submitting this job to EMR
 import sbtlighter._
 
-sparkEmrRelease := "emr-5.23.0"
+sparkEmrRelease := "emr-5.29.0"
 sparkAwsRegion := "$aws_region$"
 sparkClusterName := "$name$"
 sparkEmrApplications := Seq("Spark", "Zeppelin", "Ganglia")

--- a/src/main/g8/default.properties
+++ b/src/main/g8/default.properties
@@ -3,10 +3,9 @@ organization = geotrellis.batch
 description = This template can be used to create Spark batch jobs using GeoTrellis
 
 scala_version = 2.11.12
-sbt_version=1.2.8
-geotrellis_version=2.3.0
-geotrellis_contrib_version=2.11.0
-spark_version=2.4.0
+sbt_version=1.3.8
+geotrellis_version=3.3.0
+spark_version=2.4.4
 
 aws_region=us-east-1
 ec2_key=geotrellis-emr

--- a/src/main/g8/default.properties
+++ b/src/main/g8/default.properties
@@ -10,3 +10,4 @@ spark_version=2.4.4
 aws_region=us-east-1
 ec2_key=geotrellis-emr
 emr_job_uri=s3://geotrellis-test/jobs
+emr_version=emr-5.29.0

--- a/src/main/g8/project/plugins.sbt
+++ b/src/main/g8/project/plugins.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.2")
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.9")
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.10")
 addSbtPlugin("net.pishen" % "sbt-lighter" % "1.2.0")

--- a/src/main/g8/src/main/scala/Main.scala
+++ b/src/main/g8/src/main/scala/Main.scala
@@ -1,28 +1,23 @@
 package geotrellis.batch
 
+import geotrellis.layer._
+import geotrellis.vector._
+import geotrellis.proj4._
 import geotrellis.raster._
-import geotrellis.raster.histogram.Histogram
-import geotrellis.raster.io._
 import geotrellis.spark._
-import geotrellis.spark.pyramid.Pyramid
-import geotrellis.spark.tiling.ZoomedLayoutScheme
-import geotrellis.spark.io._
-import geotrellis.spark.io.index.ZCurveKeyIndexMethod
-import geotrellis.spark.io.kryo.KryoRegistrator
-import geotrellis.proj4.WebMercator
 
 import cats.implicits._
 import com.monovore.decline._
 
 import org.apache.spark._
-import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql._
 import org.apache.spark.rdd._
 
 import scala.util.Properties
 
 object Main extends CommandApp(
   name = "$name$",
-  header = "Creates a Spark batch job",
+  header = "GeoTrellis Spark: $name$",
   main = {
     val inputsOpt = Opts.options[String]("inputPath", help = "The path that points to data that will be read")
     val outputOpt = Opts.option[String]("outputPath", help = "The path of the output catlaog")
@@ -31,7 +26,7 @@ object Main extends CommandApp(
     (inputsOpt, outputOpt, numPartitionsOpt).mapN { (inputs, output, numPartitions) =>
       val conf = new SparkConf()
         .setIfMissing("spark.master", "local[*]")
-        .setAppName("GeoTrellis Batch Job")
+        .setAppName("$name$")
         .set("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
         .set("spark.kryo.registrator", "geotrellis.spark.io.kryo.KryoRegistrator")
         .set("spark.executionEnv.AWS_PROFILE", Properties.envOrElse("AWS_PROFILE", "default"))
@@ -39,9 +34,11 @@ object Main extends CommandApp(
       implicit val spark = SparkSession.builder.config(conf).enableHiveSupport.getOrCreate
       implicit val sc = spark.sparkContext
 
-      // Job logic ...
-
-      spark.stop()
+      try {
+        // Job logic ...
+      } finally {
+        spark.stop()
+      }
     }
   }
 )


### PR DESCRIPTION
## Testing

Bumps to latest version of GeoTrellis and cleans up some things


```sh
 sbt new geotrellis/geotrellis-spark-job.g8 --branch geotrellis-330
```

Example run:

```
/tmp ❯❯❯ sbt new geotrellis/geotrellis-spark-job.g8 --branch geotrellis-330
[info] Loading global plugins from /Users/eugene/.sbt/0.13/plugins
[info] Set current project to tmp (in build file:/private/tmp/)

This template can be used to create Spark batch jobs using GeoTrellis

name [geotrellis-spark-job]: my-project
organization [geotrellis.batch]:
scala_version [2.11.12]:
sbt_version [1.3.8]:
geotrellis_version [3.3.0]:
spark_version [2.4.4]:
aws_region [us-east-1]:
ec2_key [geotrellis-emr]:
emr_job_uri [s3://geotrellis-test/jobs]:
emr_version [emr-5.29.0]:

Template applied in ./my-project

/tmp ❯❯❯ cd my-project
/t/my-project ❯❯❯ sbt
[info] Loading settings for project global-plugins from plugins.sbt,sonatype.sbt,gpg.sbt ...
[info] Loading global plugins from /Users/eugene/.sbt/1.0/plugins
[info] Loading settings for project my-project-build from plugins.sbt ...
[info] Loading project definition from /private/tmp/my-project/project
[warn] There may be incompatibilities among your library dependencies; run 'evicted' to see detailed eviction warnings.
[info] Loading settings for project my-project from build.sbt ...
[info] Set current project to my-project (in build file:/private/tmp/my-project/)
[info] sbt server started at local:///Users/eugene/.sbt/1.0/server/c6a56c54d1a9a0f8c9c0/sock
sbt:my-project> test:runMain geotrellis.batch.Main --inputPath s3://asdf --outputPath s3://asdf
[warn] There may be incompatibilities among your library dependencies; run 'evicted' to see detailed eviction warnings.
[info] Compiling 1 Scala source to /private/tmp/my-project/target/scala-2.11/classes ...
[info] running (fork) geotrellis.batch.Main --inputPath s3://asdf --outputPath s3://asdf
log4j:WARN No appenders could be found for logger (org.apache.hadoop.util.Shell).
log4j:WARN Please initialize the log4j system properly.
log4j:WARN See http://logging.apache.org/log4j/1.2/faq.html#noconfig for more info.
Using Spark's default log4j profile: org/apache/spark/log4j-defaults.properties
20/04/16 14:09:40 INFO SparkContext: Running Spark version 2.4.4
20/04/16 14:09:41 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
20/04/16 14:09:41 INFO SparkContext: Submitted application: my-project
20/04/16 14:09:41 INFO SecurityManager: Changing view acls to: eugene
20/04/16 14:09:41 INFO SecurityManager: Changing modify acls to: eugene
20/04/16 14:09:41 INFO SecurityManager: Changing view acls groups to:
20/04/16 14:09:41 INFO SecurityManager: Changing modify acls groups to:
20/04/16 14:09:41 INFO SecurityManager: SecurityManager: authentication disabled; ui acls disabled; users  with view permissions: Set(eugene); groups with view permissions: Set(); users  with modify permissions: Set(eugene); groups with modify permissions: Set()
20/04/16 14:09:41 INFO Utils: Successfully started service 'sparkDriver' on port 55119.
20/04/16 14:09:41 INFO SparkEnv: Registering MapOutputTracker
20/04/16 14:09:41 INFO SparkEnv: Registering BlockManagerMaster
20/04/16 14:09:41 INFO BlockManagerMasterEndpoint: Using org.apache.spark.storage.DefaultTopologyMapper for getting topology information
20/04/16 14:09:41 INFO BlockManagerMasterEndpoint: BlockManagerMasterEndpoint up
20/04/16 14:09:41 INFO DiskBlockManager: Created local directory at /private/var/folders/8d/3bktmpjx02z1l3v2p4wgg7q00000gp/T/blockmgr-670151ea-3992-4e5a-909b-de88cb410669
20/04/16 14:09:41 INFO MemoryStore: MemoryStore started with capacity 2004.6 MB
20/04/16 14:09:41 INFO SparkEnv: Registering OutputCommitCoordinator
20/04/16 14:09:42 INFO Utils: Successfully started service 'SparkUI' on port 4040.
20/04/16 14:09:42 INFO SparkUI: Bound SparkUI to 0.0.0.0, and started at http://bear:4040
20/04/16 14:09:42 INFO Executor: Starting executor ID driver on host localhost
20/04/16 14:09:42 INFO Utils: Successfully started service 'org.apache.spark.network.netty.NettyBlockTransferService' on port 55120.
20/04/16 14:09:42 INFO NettyBlockTransferService: Server created on bear:55120
20/04/16 14:09:42 INFO BlockManager: Using org.apache.spark.storage.RandomBlockReplicationPolicy for block replication policy
20/04/16 14:09:42 INFO BlockManagerMaster: Registering BlockManager BlockManagerId(driver, bear, 55120, None)
20/04/16 14:09:42 INFO BlockManagerMasterEndpoint: Registering block manager bear:55120 with 2004.6 MB RAM, BlockManagerId(driver, bear, 55120, None)
20/04/16 14:09:42 INFO BlockManagerMaster: Registered BlockManager BlockManagerId(driver, bear, 55120, None)
20/04/16 14:09:42 INFO BlockManager: Initialized BlockManager: BlockManagerId(driver, bear, 55120, None)
20/04/16 14:09:42 INFO SparkUI: Stopped Spark web UI at http://bear:4040
20/04/16 14:09:42 INFO MapOutputTrackerMasterEndpoint: MapOutputTrackerMasterEndpoint stopped!
20/04/16 14:09:42 INFO MemoryStore: MemoryStore cleared
20/04/16 14:09:42 INFO BlockManager: BlockManager stopped
20/04/16 14:09:42 INFO BlockManagerMaster: BlockManagerMaster stopped
20/04/16 14:09:42 INFO OutputCommitCoordinator$OutputCommitCoordinatorEndpoint: OutputCommitCoordinator stopped!
20/04/16 14:09:42 INFO SparkContext: Successfully stopped SparkContext
20/04/16 14:09:42 INFO ShutdownHookManager: Shutdown hook called
20/04/16 14:09:42 INFO ShutdownHookManager: Deleting directory /private/var/folders/8d/3bktmpjx02z1l3v2p4wgg7q00000gp/T/spark-e6b8cf4d-503b-484b-96ff-10f4c018acf9
[success] Total time: 12 s, completed Apr 16, 2020 2:09:42 PM
```
Closes https://github.com/locationtech/geotrellis/issues/3110